### PR TITLE
Handle stale QR codes by restarting WhatsApp sessions

### DIFF
--- a/backend/src/controllers/session.controller.js
+++ b/backend/src/controllers/session.controller.js
@@ -6,10 +6,12 @@ const {
   closeSession,
   getSessionChats,
   getSessionGroups,
-  getGroupParticipants
+  getGroupParticipants,
+  restartSession
 } = require('../services/sessionManager');
 
 const prisma = new PrismaClient();
+const STALE_QR_THRESHOLD_MS = 2 * 60 * 1000;
 
 /**
  * Get all sessions
@@ -192,10 +194,18 @@ async function updateSession(req, res, next) {
 async function deleteSession(req, res, next) {
   try {
     const { id } = req.params;
+    const sessionId = parseInt(id, 10);
+
+    if (Number.isNaN(sessionId)) {
+      return res.status(400).json({
+        status: 'error',
+        message: 'Invalid session ID'
+      });
+    }
 
     // Check if session exists
     const existingSession = await prisma.session.findUnique({
-      where: { id: parseInt(id) }
+      where: { id: sessionId }
     });
 
     if (!existingSession) {
@@ -318,10 +328,18 @@ async function stopSession(req, res, next) {
 async function getSessionQR(req, res, next) {
   try {
     const { id } = req.params;
+    const sessionId = parseInt(id, 10);
+
+    if (Number.isNaN(sessionId)) {
+      return res.status(400).json({
+        status: 'error',
+        message: 'Invalid session ID'
+      });
+    }
 
     // Check if session exists
     const existingSession = await prisma.session.findUnique({
-      where: { id: parseInt(id) }
+      where: { id: sessionId }
     });
 
     if (!existingSession) {
@@ -332,27 +350,59 @@ async function getSessionQR(req, res, next) {
     }
 
     // Get session
-    const session = getSession(parseInt(id));
+    const session = getSession(sessionId);
 
     // If session is not initialized, initialize it
     if (!session) {
-      await initializeSession(parseInt(id));
+      await initializeSession(sessionId);
     }
 
     // Get QR code from database (it's updated by the session manager)
-    const updatedSession = await prisma.session.findUnique({
-      where: { id: parseInt(id) },
+    const sessionState = await prisma.session.findUnique({
+      where: { id: sessionId },
       select: {
         qrCode: true,
-        status: true
+        status: true,
+        updatedAt: true
       }
     });
+
+    let qrCode = sessionState?.qrCode || null;
+    let statusValue = sessionState?.status || existingSession.status;
+
+    const lastUpdateDate = sessionState?.updatedAt || existingSession.updatedAt;
+    const lastUpdate = lastUpdateDate ? new Date(lastUpdateDate).getTime() : null;
+    const qrAge = lastUpdate ? Date.now() - lastUpdate : null;
+    const qrIsStale =
+      Boolean(qrCode) &&
+      statusValue === 'connecting' &&
+      typeof qrAge === 'number' &&
+      qrAge > STALE_QR_THRESHOLD_MS;
+
+    if (qrIsStale) {
+      logger.info(
+        `QR code for session ${sessionId} is ${qrAge}ms old and stale. Restarting session to generate a fresh code.`
+      );
+
+      await restartSession(sessionId);
+
+      const refreshedState = await prisma.session.findUnique({
+        where: { id: sessionId },
+        select: {
+          qrCode: true,
+          status: true
+        }
+      });
+
+      qrCode = refreshedState?.qrCode || null;
+      statusValue = refreshedState?.status || 'connecting';
+    }
 
     res.status(200).json({
       status: 'success',
       data: {
-        qr_code: updatedSession.qrCode,
-        status: updatedSession.status
+        qr_code: qrCode,
+        status: statusValue
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- detect stale WhatsApp QR codes when fetching them and restart the session to force regeneration
- add a session restart helper that tears down the existing client, resets status, and reinitializes the client
- guard the QR endpoint against invalid session IDs while keeping responses up to date after a restart

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37f78cae08329aec7e2412b5f4411